### PR TITLE
Add createRound function and matching test

### DIFF
--- a/src/card.js
+++ b/src/card.js
@@ -20,7 +20,7 @@ const createDeck = cards => {
   let deck = {
     cards: cards,
   };
-  console.log(deck);
+  // console.log(deck);
   return deck;
 };
 
@@ -28,9 +28,25 @@ const countCards = arrOfCards => {
   return deck.cards.length;
 };
 
+const createRound = (
+  deck,
+  currentCardIndex = 0,
+  turns = 0,
+  incorrectGuesses = []
+) => {
+  let round = {
+    deck: deck,
+    currentCard: deck.cards[currentCardIndex],
+    turns: turns,
+    incorrectGuesses: incorrectGuesses,
+  };
+  return round;
+};
+
 module.exports = {
   createCard,
   evaluateGuess,
   createDeck,
   countCards,
+  createRound,
 };

--- a/test/Card-test.js
+++ b/test/Card-test.js
@@ -6,6 +6,7 @@ const {
   evaluateGuess,
   createDeck,
   countCards,
+  createRound,
 } = require('../src/card');
 
 describe('card', function () {
@@ -63,53 +64,65 @@ describe('guess', function () {
 });
 
 describe(`deck functions`, () => {
-  it('should create an array of card objects', () => {
-    const card1 = createCard(
+  let card1, card2, card3, deck;
+
+  beforeEach(() => {
+    card1 = createCard(
       1,
       "What is Robbie's favorite animal",
       ['sea otter', 'pug', 'capybara'],
       'sea otter'
     );
-    const card2 = createCard(
+    card2 = createCard(
       14,
       'What organ is Khalid missing?',
       ['spleen', 'appendix', 'gallbladder'],
       'gallbladder'
     );
-    const card3 = createCard(
+    card3 = createCard(
       12,
       "What is Travis's favorite stress reliever?",
       ['listening to music', 'watching Netflix', 'playing with bubble wrap'],
       'playing with bubble wrap'
     );
-
-    const deck = createDeck([card1, card2, card3]);
-
+    deck = createDeck([card1, card2, card3]);
+  });
+  it('should create an array of card objects', () => {
     expect(deck.cards).to.deep.equal([card1, card2, card3]);
   });
 
   it('should get the length of a deck', () => {
-    const card1 = createCard(
+    expect(deck.cards.length).to.equal(3);
+  });
+});
+
+describe('round functions', () => {
+  let card1, card2, card3, deck;
+
+  beforeEach(() => {
+    card1 = createCard(
       1,
       "What is Robbie's favorite animal",
       ['sea otter', 'pug', 'capybara'],
       'sea otter'
     );
-    const card2 = createCard(
+    card2 = createCard(
       14,
       'What organ is Khalid missing?',
       ['spleen', 'appendix', 'gallbladder'],
       'gallbladder'
     );
-    const card3 = createCard(
+    card3 = createCard(
       12,
       "What is Travis's favorite stress reliever?",
       ['listening to music', 'watching Netflix', 'playing with bubble wrap'],
       'playing with bubble wrap'
     );
+    deck = createDeck([card1, card2, card3]);
+  });
 
-    const deck = createDeck([card1, card2, card3]);
-
-    expect(deck.cards.length).to.equal(3);
+  it('should create a round of the game', () => {
+    const gameRound = createRound(deck, 0, 0, []);
+    // console.log('gameRound', gameRound);
   });
 });


### PR DESCRIPTION
Adds the createRound function and its matching test.  I had a bit of help with this function.  The currentCard property wasn't jiving for me.  I had the currentCardIndex as an argument coming in but without help I wasn't getting anything to work.  The way this is coded now, we're accessing the deck.cards and referencing the its index number.  

This was where I started:
const createRound = (
  deck,
  currentCardIndex = 0,
  turns = 0,
  incorrectGuesses = []
) => {
  let round = {
    deck: deck,
    currentCard: currentCardIndex,
    turns: turns,
    incorrectGuesses: incorrectGuesses,
  };
  return round;
};

The FIX:
currentCard: deck.cards[currentCardIndex] //uses the card object and finds the index